### PR TITLE
Fix handler initialization order and proper BeginString

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,8 +45,10 @@ def client(fix_version, host, port):
     """
     click.echo(f"Starting Market Sim Client for FIX.{fix_version} connecting to {host}:{port}...")
     try:
-        # Construct the BeginString from the version
-        begin_string = f"FIX.{fix_version.replace('.', '')}".encode()
+        # Construct the BeginString from the version. We expect a value like
+        # "4.2" or "4.4" and need to pass "FIX.<ver>" (e.g. "FIX.4.2") to the
+        # client so the simulator can locate the correct dictionary.
+        begin_string = f"FIX.{fix_version}".encode()
         market_sim_client.run_client(host, port, begin_string)
     except Exception as e:
         click.echo(f"An error occurred: {e}", err=True)

--- a/src/fix_sim/fix_simulator.py
+++ b/src/fix_sim/fix_simulator.py
@@ -57,10 +57,13 @@ def get_protocol(begin_string: str) -> FixProtocol:
 
 # --- Simulator Logic ---
 class FixSimulatorHandler(socketserver.BaseRequestHandler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.lp_settings = self.server.lp_settings
+    def __init__(self, request, client_address, server):
+        # The BaseRequestHandler.__init__ will call our handle() method, so
+        # any attributes needed inside handle() must be initialized *before*
+        # calling super().__init__().
+        self.lp_settings = server.lp_settings
         self.protocol = None
+        super().__init__(request, client_address, server)
 
     def handle(self):
         logger.info(f"Connection from {self.client_address}")


### PR DESCRIPTION
## Summary
- ensure FixSimulatorHandler attributes are initialized before BaseRequestHandler kicks off `handle`
- construct correct BeginString for client connections

## Testing
- `timeout 8 python main.py sim` *(fails: Address already in use)*
- `python main.py client --host localhost --port 9898 --fix-version 4.2` *(connects successfully)*

------
https://chatgpt.com/codex/tasks/task_b_6870d5d5365c832eb3a02b3d706e12c4